### PR TITLE
Minor changes in 400-600px media query plus added print media CSS

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -65,7 +65,7 @@ p { font-size: 1.4rem;
      }
 @media screen and (max-width: 600px){
     p{
-      width: 70%;
+      width: 65%;
     }
     }     
 @media screen and (max-width: 400px){
@@ -100,7 +100,7 @@ sub { top: 0.4rem; }
 @media screen and (max-width: 600px){
     .sidenote, .marginnote{
       width: 25%;
-      margin-right: -40%;
+      margin-right: -35%;
     }
     }
 @media screen and (max-width: 400px){

--- a/tufte.css
+++ b/tufte.css
@@ -205,3 +205,41 @@ span.newthought { font-variant: small-caps; }
              vertical-align: 0.15rem;
              margin-left: -0.36rem;
              margin-right: -0.15rem; }
+/*--- Media query for printing --*/
+@media print {
+    *,
+    *:before,
+    *:after {
+        background: transparent !important;
+        color: #000 !important; /* Black prints faster:
+                                   http://www.sanbeiji.com/archives/953 */
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+
+    thead {
+        display: table-header-group;
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+    h3 {
+        page-break-after: avoid;
+    }
+} 


### PR DESCRIPTION
Modifiied the < 600px media query to give the marginnote / sidenote more breathing room on the right margin. Looks better, IMO. I also just cribbed a portion of the HTML5 boilerplate to add some print media query stying. Main effect is just to print the background and text in black and white instead of the nice colors seen on the screen media query.
