### PR TITLE
Increase x-height of inline code

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -144,7 +144,7 @@ p, footer, pre.code { width: 55%; }
 
 .code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
         color: #222;
-        font-size: 1rem;
+        font-size: 1.125rem;
         line-height: 1.6; }
 
 pre.code { padding: 0 0 0 2em; }
@@ -156,4 +156,3 @@ pre.code { padding: 0 0 0 2em; }
 @media screen and (max-width: 400px) { .sidenote-number, .sidenote, .marginnote { display: none; }}
 
 span.newthought { font-variant: small-caps; }
-


### PR DESCRIPTION
In [this Tufte sample handout PDF](https://tufte-latex.googlecode.com/files/sample-handout-3.5.0.pdf), the inline monospace font has the same x-height as its surrounding serif text. So, I’m increasing the code font size from 16px to 18px, which looks right to me.
