### PR TITLE
Provide 'booktabs' style for tables.

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,23 @@
         </table>
       </p>
       <p>Please understand: this is not the One True Table. Such a style does not exist. One must craft each data table with custom care to the narrative one is telling with that specific data. So take this not as "the table style to use", but rather as "a table style to start from". From here, use principles to guide you: avoid chartjunk, optimize the data-ink ratio ("within reason", as Tufte says), and "mobilize every graphical element, perhaps several times over, to show the data."<span class="sidenote-number"></span><span class="sidenote">Page 139, The Visual Display of Quantitative Information, Edward Tufte 2001.</span> Know when to reach for more complex data presentation tools, like a custom graphic or a JavaScript charting library.</p>
+      <p>A common table style used in academic publications is provided by the <tt>booktabs</tt> class (see Table&nbsp;2 for an example). The table is surrounded by heavy rules on the top and bottom. A lighter-weight rule is used to separate the table head from its body. If you need a column heading to span two or more other column headings, an even lighter-weight rule may be used. Vertical rules are unnecessary. Additionally, the spacing around the rules has been increased to avoid a cramped appearance.</p>
+      <p>
+        <span class="marginnote">Table 2: An example table demonstrating the <tt>booktabs</tt> class.</span>
+        <table class="booktabs">
+          <thead>
+            <tr><th colspan="2" class="cmid">Items</th><th class="nocmid"></th></tr>
+            <tr><th>Animal</th><th>Description</th><th>Price ($)</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Gnat</td>     <td>per gram</td><td class="r">13.65</td></tr>
+            <tr><td></td>         <td>each</td>    <td class="r">0.01</td></tr>
+            <tr><td>Gnu</td>      <td>stuffed</td> <td class="r">92.50</td></tr>
+            <tr><td>Emu</td>      <td>stuffed</td> <td class="r">33.33</td></tr>
+            <tr><td>Armadillo</td><td>frozen</td>  <td class="r">8.99</td></tr>
+          </tbody>
+        </table>
+      </p>
     </section>
 
     <section>

--- a/tufte.css
+++ b/tufte.css
@@ -65,6 +65,43 @@ thead th { border-bottom: 1px solid #AAAAAA;
 
 td.text { text-align: left; }
 
+table.booktabs { width: auto;
+                 max-width: 53%;
+                 margin-left: auto;  /* center the table */
+                 margin-right: auto;
+                 border-spacing: 0px;
+                 border-top: 2px solid #333333;
+                 border-bottom: 2px solid #333333; }
+
+.booktabs th { border-bottom: 1px solid #333333;
+               padding: 0.65ex 0.5em 0.4ex 0.5em;
+               font-weight: normal;
+               text-align: center; }
+
+.booktabs th.cmid { border-bottom: 1px solid #666666; }
+
+.booktabs th.nocmid { border-bottom: none; }
+
+.booktabs tbody tr:first-child td {
+    /* add 0.65ex space between thead row and tbody */
+    padding-top: 0.65ex; }
+
+.booktabs td { padding-left: 0.5em;
+              padding-right: 0.5em;
+              text-align: left; }
+
+.booktabs caption { font-size: 90%;
+                    text-align: left;
+                    width: auto;
+                    margin-left: auto;
+                    margin-right: auto;
+                    margin-top: 1ex;
+                    caption-side: bottom; }
+
+.l { text-align: left !important; }
+.c { text-align: center !important; }
+.r { text-align: right !important; }
+
 article { position: relative;
           padding: 5rem 0rem; }
 


### PR DESCRIPTION
**This pull request is intended to elicit feedback.**

The [booktabs package](http://ctan.org/pkg/booktabs) provides nice rules and spacing for tables. Tables of this style are frequently used in academic journals.

A heavy rule is used at the top and bottom of the table. A medium-weight rule is separates the head row from the table contents.

One unresolved issue: centering the table by default. I almost always center my tables and I want them to only be as wide as necessary (not expand to consume 100% of the width available). This pull request centers the table, but it's offset slight—I think due to the gap between the main text block and the sidenotes area.

Future potential features:
- `\addlinespace` functionality to add additional spacing between a specific row. This is useful for lengthy tables. Providing periodic spacing improves readability without resorting to zebra backgrounds and the like.
- `\cmidrule`s where the width of the rule can be adjusted to provide gaps between adjacent rules.
