### PR TITLE
Adjusted code snippets' font-size when in headings, fixes daveliepmann/tufte-css#33

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -150,6 +150,8 @@ p, footer, pre.code { width: 55%; }
         font-size: 1.125rem;
         line-height: 1.6; }
 
+h1 .code, h2 .code, h3 .code { font-size: 0.80em; }
+
 pre.code { padding: 0 0 0 2em; }
 
 .fullwidth { max-width: 95%; }


### PR DESCRIPTION
Used the ratio of code-to-regular-text font-size in non-headers: 1.125 / 1.4 =
0.80357.
