### PR TITLE
Improved handling of sidenotes on small screens.

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -158,7 +158,7 @@ pre.code { padding: 0 0 0 2em; }
 
 @media screen and (max-width: 600px) { .sidenote, .marginnote { width: 35%;
                                                                 margin-right: -45%; }}
-@media screen and (max-width: 400px) { .sidenote-number { display: none; }
+@media screen and (max-width: 400px) { .sidenote-number { visibility: hidden; }
                                        .sidenote, .marginnote { width: 50%;
                                                                 margin: 0.5em;
                                                                 margin-right: -5%; }}

--- a/tufte.css
+++ b/tufte.css
@@ -158,6 +158,11 @@ pre.code { padding: 0 0 0 2em; }
 
 @media screen and (max-width: 600px) { .sidenote, .marginnote { width: 35%;
                                                                 margin-right: -45%; }}
-@media screen and (max-width: 400px) { .sidenote-number, .sidenote, .marginnote { display: none; }}
+@media screen and (max-width: 400px) { .sidenote-number { display: none; }
+                                       .sidenote, .marginnote { width: 50%;
+                                                                margin: 0.5em;
+                                                                margin-right: -5%; }}
+@media screen and (max-width: 300px) { .sidenote, .marginnote { margin-right: 0; }}
+
 
 span.newthought { font-variant: small-caps; }


### PR DESCRIPTION
Obviously handling sidenotes on small screens is tricky, since we cannot look to any print models. This is a proposal based on my own experience attempting Tufte-esque layouts in CSS.

On small screens (<400px), instead of being hidden, the sidenotes are flowed into the text block. A wider CSS margin, and a slight protrusion into the margin of the page, keep them visually distinct. And on very small screens (<300px) even that slight protrustion is omitted.

It is also necessary to hide the sidenote numbers in the text, since otherwise they would be displayed right next to the sidenote’s own number, which is very distracting.
