### PR TITLE
Link styles

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -17,6 +17,14 @@ body { width: 87.5%;
        max-width: 1400px;
        counter-reset: sidenote-counter; }
 
+::-moz-selection { background: #444;
+                   color: #fff;
+                   text-shadow: none; }
+
+selection { background: #444;
+            color: #fff;
+            text-shadow: none; }
+
 h1 { font-weight: 400;
      margin-top: 4rem;
      margin-bottom: 1.5rem;
@@ -137,9 +145,18 @@ figcaption { float: right;
 figure.fullwidth figcaption { margin-right: 24%; }
 
 a { color: #111;
+    background-image: linear-gradient(#111, #111);
+    background-position: 0 86%;
+    background-repeat: repeat-x;
+    background-size: 1px 1px;
     text-decoration: none;
-    border-bottom: 1px solid #777;
-    padding-bottom: 1px; }
+    text-shadow: 0.03em 0 #fffff8 , -0.03em 0 #fffff8 , 0 0.03em #fffff8 , 0 -0.03em #fffff8 , 0.2em 0 #fffff8 , -0.2em 0 #fffff8 , 0.09em 0 #fffff8 , -0.09em 0 #fffff8 , 0.12em 0 #fffff8 , -0.12em 0 #fffff8 , 0.15em 0 #fffff8 , -0.15em 0 #fffff8; }
+
+a sup { opacity: 0.99;
+        text-shadow: none; }
+
+a:hover { color: #f05;
+          background-image: linear-gradient(#f05, #f05); }
 
 img { max-width: 100%; }
 

--- a/tufte.css
+++ b/tufte.css
@@ -146,7 +146,7 @@ figure.fullwidth figcaption { margin-right: 24%; }
 
 a { color: #111;
     background-image: linear-gradient(#111, #111);
-    background-position: 0 86%;
+    background-position: 0 87%;
     background-repeat: repeat-x;
     background-size: 1px 1px;
     text-decoration: none;
@@ -154,9 +154,6 @@ a { color: #111;
 
 a sup { opacity: 0.99;
         text-shadow: none; }
-
-a:hover { color: #f05;
-          background-image: linear-gradient(#f05, #f05); }
 
 img { max-width: 100%; }
 


### PR DESCRIPTION
Current link styles use border-bottom , but the line is in the middle of the leading, and thus becomes obtrusive.

This pull requests is based on [a technique](https://eager.io/blog/smarter-link-underlines/) of styling the links using CSS gradients and text-shadow.

This solution however requires additional selection styles and limits the colors that may be used for the background.

Also added hover styles to better inform the viewer that the link is clickable.
