### PR TITLE
Link hover

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -141,7 +141,13 @@ figure.fullwidth figcaption { margin-right: 24%; }
 a { color: #111;
     text-decoration: none;
     border-bottom: 1px solid #777;
-    padding-bottom: 1px; }
+    padding-bottom: 1px;
+    -webkit-transition: all .3s;
+    -moz-transition: all .3s;
+    transition: all .3s; }
+
+a:hover { color: #f05;
+          border-color: #f05; }
 
 img { max-width: 100%; }
 


### PR DESCRIPTION
Per Dave’s suggestion over at https://github.com/daveliepmann/tufte-css/pull/43#issuecomment-131164733, I’m proposing a PR for colored links on hover.

It’s been 11 years since [Jacob Nielsen’s guidelines](http://www.nngroup.com/articles/guidelines-for-visualizing-links/)  and a lot of sites nowadays —notably [Medium](https://medium.com/designing-medium/crafting-link-underlines-on-medium-7c03a9274f9)— don’t offer different styles for hover.

They may only be relevant to desktop users, but in my opinion hover styles are indispensable in how they strongly inform the reader that the underlined phrase they put their cursor on, is actually a link.
