### PR TITLE
Replace curved quotes in HTML tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
     <section>
       <h2>Figures</h2>
       <p>Tufte emphasizes tight integration of graphics with text. Data, graphs, and figures are kept with the text that discusses them. In print, this means they are not relegated to a separate page. On the web, that means readability of graphics and their accompanying text without extra clicks, tab-switching, or scrolling.</p>      
-      <p>Figures should try to use the <span class=”code”>figure</span> element, which by default are constrained to the main column. Don’t wrap figures in a paragraph tag. Any label or margin note goes in a <span class="code">figcaption</span> tag inside the figure. For example, most of the time I should introduce a figure directly into the main flow of discussion, like so:</p>
+      <p>Figures should try to use the <span class="code">figure</span> element, which by default are constrained to the main column. Don’t wrap figures in a paragraph tag. Any label or margin note goes in a <span class="code">figcaption</span> tag inside the figure. For example, most of the time I should introduce a figure directly into the main flow of discussion, like so:</p>
       <figure>
         <img src="figure3.png"/>
         <figcaption>Figure 3: A figure the width of the main column</figcaption>
@@ -187,8 +187,8 @@
       <p>Tufte CSS attempts only to cover some basic “Tuftean” ideas, providing one possible set of defaults, using cascading stylesheets. Therefore many of the more interesting techniques he points to are far outside the scope of this project. Graphing data, interactive data visualizations, and non-traditional text formats are fantastic tools that aren’t covered by Tufte CSS. Here is a short and incomplete overview of tools that can help accomplish a few Tufte-like techniques.</p>
       <p>Sparklines are awesome, and can be created in a variety of ways. People are making them with <a href="https://github.com/adactio/Canvas-Sparkline">plain javascript</a>, <a href="http://omnipotent.net/jquery.sparkline/#s-about">jQuery</a>, <a href="http://www.tnoda.com/blog/2013-12-19">d3.js</a>, and <a href="http://www.highcharts.com/demo/sparkline">HighCharts</a>. Evaluate those solutions to see which is most appropriate for your needs.</p>
       <p>If you need to display mathematical symbols and equations, I hear <a href="http://www.mathjax.org/">MathJax</a> is good.</p>
-      <p>Although I don’t follow all of its prescriptions, I like <a href=”http://practicaltypography.com/”>Butterick’s Practical Typography</a> for its thoughts on designing text for the web.</p>
-      <p> Bret Victor’s has published some vintage computer science talks and papers, like <a href=”http://worrydream.com/EnlightenedImaginationForCitizens/”>this one by Alan Kay</a>, that have a Tufte-CSS feel that I quite like.</p>
+      <p>Although I don’t follow all of its prescriptions, I like <a href="http://practicaltypography.com/">Butterick’s Practical Typography</a> for its thoughts on designing text for the web.</p>
+      <p> Bret Victor’s has published some vintage computer science talks and papers, like <a href="http://worrydream.com/EnlightenedImaginationForCitizens/">this one by Alan Kay</a>, that have a Tufte-CSS feel that I quite like.</p>
     </section>
   </article>
 </body>


### PR DESCRIPTION
These quote marks should be "straight" quote marks, as they are part of the HTML tag, not the text. Currently they are interpreted as part of the attribute value, and breaking the style and the links.
