### PR TITLE
Fixes table-caption/table layout issue in Firefox

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -45,6 +45,7 @@ p.subtitle { font-style: italic;
              line-height: 1; }
 
 table { width: 98%;
+        clear: left;
         text-align: right;
         font-size: 1.2rem;
         line-height: 1.4;


### PR DESCRIPTION
Inserted `clear: left` in CSS for `table` so table would be positioned below table-caption, instead of colliding with it at mobile widths in Firefox 40.0.3/Mac.

Chrome, Safari, Opera (e.g., below, left) are OK, but at mobil-ish widths, Firefox 40.0.3/Mac (below, right) fumbles the table-caption layout:

![scrap-tuftecss-tables-sqz](https://cloud.githubusercontent.com/assets/1248937/9588418/2ae1a828-4ff6-11e5-9e9b-db93aa5ee1e1.jpg)

Inserting an explicit clear: left in the CSS for table seems to fix it, causing tables to be positioned below table-captions, instead of colliding with them in Firefox.
