### PR TITLE
Firefox image fix

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -128,10 +128,15 @@ ul { width: 45%;
 
 li { padding: 0.5rem 0; }
 
-figure { max-width: 55%;
+figure { padding: 0;
+         border: 0;
+         font-size: 100%;
+         font: inherit;
+         vertical-align: baseline;
+         max-width: 55%;
          -webkit-margin-start: 0;
          -webkit-margin-end: 0;
-         margin-bottom: 3em; }
+         margin: 0 0 3em 0; }
 
 figcaption { float: right;
              clear: right;


### PR DESCRIPTION
After using @crmackay fix there was still an additional margin of 40px which was probably added by Firefox default css. I added a browser reset for the `figure` element and now the versions are identical.

Fixes edwardtufte/tufte-css#53
