### PR TITLE
fixes #56 by adding indentation to ordered lists

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -119,7 +119,7 @@ table.booktabs { width: auto;
 
 .booktabs th.nocmid { border-bottom: none; }
 
-.booktabs tbody tr:first-child td { padding-top: 0.65ex; } /* add space between thead row and tbody */ 
+.booktabs tbody tr:first-child td { padding-top: 0.65ex; } /* add space between thead row and tbody */
 
 .booktabs td { padding-left: 0.5em;
                padding-right: 0.5em;
@@ -173,10 +173,11 @@ blockquote footer { width: 50%;
                     font-size: 1.1rem;
                     text-align: right; }
 
-ul { width: 45%;
-     -webkit-padding-start: 5%;
-     -webkit-padding-end: 5%;
-     list-style-type: none; }
+ol, ul { width: 45%;
+         -webkit-padding-start: 5%;
+         -webkit-padding-end: 5%; }
+         
+ul { list-style-type: none; }
 
 li { padding: 0.5rem 0; }
 
@@ -289,7 +290,7 @@ pre.code { width: 52.5%;
            padding-left: 2.5%;
            overflow-x: scroll; }
 
-.fullwidth { max-width: 90%; 
+.fullwidth { max-width: 90%;
              clear:both; }
 
 span.newthought { font-variant: small-caps;
@@ -303,7 +304,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
 
 @media (max-width: 760px) { label.margin-toggle:not(.sidenote-number) { display: inline; }
                             .sidenote, .marginnote { display: none; }
-                            .margin-toggle:checked + .sidenote, 
+                            .margin-toggle:checked + .sidenote,
                             .margin-toggle:checked + .marginnote { display: block;
                                                                    float: left;
                                                                    left: 1rem;
@@ -313,7 +314,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
                                                                    vertical-align: baseline;
                                                                    position: relative; }
                             label { cursor: pointer; }
-                            pre.code { width: 90%; 
+                            pre.code { width: 90%;
                                        padding: 0; }
                             .table-caption { display: block;
                                              float: right;


### PR DESCRIPTION
I guess, you missed the `ol`-Tag for reason as the webpage mentions _that while lists have valid uses, they tend to promote ineffective writing habits due to their “lack of syntactic and intellectual discipline”_. 

Howsoever … to stick with the typographical flow, I imagine you just want the same indentation for ordered lists as for unordered, except for the numeration. I therefore just split the CSS rule for `ul`, using the same indention for both, `ol`and `ul`.

(The deletion of redundant spaces at line ends was done by my Atom editor.)
