### PR TITLE
LaTeX span no longer messes up the line height

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <p class="subtitle">Dave Liepmann</p>
     <section>
       <p>Tufte CSS provides tools to style web articles using the ideas demonstrated by Edward Tufte’s books and handouts. Tufte’s style is known for its simplicity, extensive use of sidenotes, tight integration of graphics with text, and carefully chosen typography.</p>
-      <p>The idea was cribbed in whole from <a href="https://tufte-latex.github.io/tufte-latex/">Tufte-<span class="latex">L<sup>a</sup>T<sub>e</sub>X</span></a> and <a href="http://rmarkdown.rstudio.com/tufte_handout_format.html">R Markdown’s Tufte Handout format</a><label for="sn-tufte-handout" class="margin-toggle sidenote-number"></label><input type="checkbox" id="sn-tufte-handout" class="margin-toggle"/>.
+      <p>The idea was cribbed in whole from <a href="https://tufte-latex.github.io/tufte-latex/">Tufte-<span class="latex">L<span class="latex-sup">a</span>T<span class="latex-sub">e</span>X</span></a> and <a href="http://rmarkdown.rstudio.com/tufte_handout_format.html">R Markdown’s Tufte Handout format</a><label for="sn-tufte-handout" class="margin-toggle sidenote-number"></label><input type="checkbox" id="sn-tufte-handout" class="margin-toggle"/>.
         <span class="sidenote">
           This page was in fact originally an adaptation of the <a href="http://rmarkdown.rstudio.com/examples/tufte-handout.pdf">Tufte Handout Example</a> PDF.
         </span> 
@@ -205,7 +205,7 @@
           Page 139, <em>The Visual Display of Quantitative Information</em>, Edward Tufte 2001.
         </span> Furthermore, one must know when to reach for more complex data presentation tools, like a custom graphic or a JavaScript charting library.</p>
 
-      <p>As an example of alternative table styles, academic publications written in <span class="latex">L<sup>a</sup>T<sub>e</sub>X</span> often rely on the <span class="code">booktabs</span> package to produce clean, clear tables. Similar results, tweaked to Tufte’s preference for minimal extraneous lines, can be achieved in Tufte CSS with the <span class="code">booktabs</span> class. Here’s a a demonstration of a booktabs-style table:</p>
+      <p>As an example of alternative table styles, academic publications written in <span class="latex">L<span class="latex-sup">a</span>T<span class="latex-sub">e</span>X</span> often rely on the <span class="code">booktabs</span> package to produce clean, clear tables. Similar results, tweaked to Tufte’s preference for minimal extraneous lines, can be achieved in Tufte CSS with the <span class="code">booktabs</span> class. Here’s a a demonstration of a booktabs-style table:</p>
       <div class="table-wrapper">
         <span class="table-caption">
           An example of a <span class="code">booktabs</span>-styled table.

--- a/latex.css
+++ b/latex.css
@@ -1,9 +1,11 @@
-.latex sub, .latex sup { text-transform: uppercase; }
+.latex-sub, .latex-sup { text-transform: uppercase;
+                         font-size: smaller;
+                         position: relative; }
 
-.latex sub { vertical-align: -0.2rem;
+.latex-sub { top: 0.2rem;
              margin-left: -0.1667rem;
              margin-right: -0.125rem; }
 
-.latex sup { vertical-align: 0.2rem;
+.latex-sup { top: -0.2rem;
              margin-left: -0.36rem;
              margin-right: -0.15rem; }


### PR DESCRIPTION
Removes the line height change whenever the formatted word LaTeX appears.

![image](https://cloud.githubusercontent.com/assets/3719275/10416458/8af2bab4-7020-11e5-86ad-f5c5ec4cb97d.png)

becomes

![image](https://cloud.githubusercontent.com/assets/3719275/10416462/9a2690f0-7020-11e5-81a5-dbbed1b2d7d5.png)
