### PR TITLE
Fix text-shadow for latex when selected and for superscript text

### DIFF
--- a/latex.css
+++ b/latex.css
@@ -8,4 +8,11 @@
 
 .latex-sup { top: -0.2rem;
              margin-left: -0.36rem;
-             margin-right: -0.15rem; }
+             margin-right: -0.15rem;
+             text-shadow: none; }
+
+.latex::selection, .latex span:not(.latex-sup)::selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
+                    background: #b4d5fe; }
+
+.latex::-moz-selection, .latex span:not(.latex-sup)::-moz-selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
+                         background: #b4d5fe; }


### PR DESCRIPTION
Text-shadow of superscript latex characters was removed because it was unnecessary and sometimes overlapped a part of adjacent characters. Proper text-shadow colors during selection were added as well.
