### PR TITLE
Add id's to headers for url navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <article>
-    <h1>Tufte CSS</h1>
+    <h1 id="tufte-css">Tufte CSS</h1>
     <p class="subtitle">Dave Liepmann</p>
     <section>
       <p>Tufte CSS provides tools to style web articles using the ideas demonstrated by Edward Tufte’s books and handouts. Tufte’s style is known for its simplicity, extensive use of sidenotes, tight integration of graphics with text, and carefully chosen typography.</p>
@@ -19,7 +19,7 @@
     </section>
 
     <section>
-      <h2>Getting Started</h2>
+      <h2 id="getting-started">Getting Started</h2>
       <p>To use Tufte CSS, copy <span class="code">tufte.css</span> and the <span class="code">et-book</span> directory of font files to your project directory, then add the following to your HTML document’s <span class="code">head</span> block:</p>
 
       <pre class="code">&lt;link rel="stylesheet"
@@ -29,8 +29,8 @@
     </section>
 
     <section>
-      <h2>Fundamentals</h2>
-      <h3>Sections and Headings</h3>
+      <h2 id="fundamentals">Fundamentals</h2>
+      <h3 id="fundamentals--sections-and-headers">Sections and Headings</h3>
       <p>Organize your document with an <span class="code">article</span> element inside your <span class="code">body</span> tag. Inside that, use <span class="code">section</span> tags around each logical grouping of text and headings.</p>
       <p>Tufte CSS uses <span class="code">h1</span> for the document title, <span class="code">p</span> with class <span class="code">subtitle</span> for the document subtitle, <span class="code">h2</span> for section headings, and <span class="code">h3</span> for low-level headings. More specific headings are not supported. If you feel the urge to reach for a heading of level 4 or greater, consider redesigning your document:</p>
       <blockquote cite="http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000hB">
@@ -40,7 +40,7 @@
       <p>As a bonus, this excerpt regarding the use of headings provides an example of block quotes. They are just lightly styled, semantically correct HTML using <span class="code">blockquote</span> and <span class="code">footer</span> elements.</p>
       <p><span class="newthought">In his later books<label for="sn-in-his-later-books" class="margin-toggle sidenote-number"></label></span><input type="checkbox" id="sn-in-his-later-books" class="margin-toggle"/><span class="sidenote"><a href="http://www.edwardtufte.com/tufte/books_be"><em>Beautiful Evidence</em></a></span>, Tufte starts each section with a bit of vertical space, a non-indented paragraph, and the first few words of the sentence set in small caps. For this we use a span with the class <span class="code">newthought</span>, as demonstrated at the beginning of this paragraph. Vertical spacing is accomplished separately through <span class="code">&lt;section&gt;</span> tags. Be consistent: though we do so in this paragraph for the purpose of demonstration, do not alternate use of header elements and the <span class="code">newthought</span> technique. Pick one approach and stick to it.</p>
 
-      <h3>Text</h3>
+      <h3 id="fundamentals--sections-and-headers">Text</h3>
       <p>Although paper handouts obviously have a pure white background, the web is better served by the use of slightly off-white and off-black colors. Tufte CSS uses <span class="code">#fffff8</span> and <span class="code">#111111</span> because they are nearly indistinguishable from their ‘pure’ cousins, but dial down the harsh contrast. We stick to the greyscale for text, reserving color for specific, careful use in figures and images.</p>
       <p>In print, Tufte has used the proprietary Monotype Bembo<label for="sn-proprietary-monotype-bembo" class="margin-toggle sidenote-number"></label><input type="checkbox" id="sn-proprietary-monotype-bembo" class="margin-toggle"/><span class="sidenote">See Tufte’s comment in the <a href="http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0000Vt">Tufte book fonts</a> thread.</span> font. A similar effect is achieved in digital formats with the now open-source <a href="https://github.com/edwardtufte/et-book">ETBook</a>, which Tufte CSS supplies with a <span class="code">@font-face</span> reference to a .ttf file. In case ETBook somehow doesn’t work, Tufte CSS shifts gracefully to other serif fonts like Palatino and Georgia.</p>
       <p>Also notice how Tufte CSS includes separate font files for bold (strong) and italic (emphasis), instead of relying on the browser to mechanically transform the text. This is typographic best practice.</p>
@@ -49,7 +49,7 @@
       <p>As always, these design choices are merely one approach that Tufte CSS provides by default. Other approaches, such as changing color on click or mouseover, or using highlighting or color instead of underlining to denote links, could also be made to work. The goal is to make sentences readable without interference from links, as well as to make links immediately identifiable even by casual web users.</p>
 
     <section>
-      <h2>Epigraphs</h2>
+      <h2 id="epigraphs">Epigraphs</h2>
       <div class="epigraph">
         <blockquote>
           <p>The English language . . . becomes ugly and inaccurate because our thoughts are foolish, but the slovenliness of our language makes it easier for us to have foolish thoughts.</p>
@@ -65,7 +65,7 @@
     </section>
 
     <section>
-      <h2>Sidenotes: Footnotes and Marginal Notes</h2>
+      <h2 id="sidenotes">Sidenotes: Footnotes and Marginal Notes</h2>
       <p>One of the most distinctive features of Tufte’s style is his extensive use of sidenotes.<label for="sn-extensive-use-of-sidenotes" class="margin-toggle sidenote-number"></label><input type="checkbox" id="sn-extensive-use-of-sidenotes" class="margin-toggle"/><span class="sidenote">This is a sidenote.</span> Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page, but instead display off to the side in the margin. Perhaps you have noticed their use in this document already. You are very astute.</p>
       <p>Sidenotes are a great example of the web not being like print. On sufficiently large viewports, Tufte CSS uses the margin for sidenotes, margin notes, and small figures. On smaller viewports, elements that would go in the margin are hidden until the user toggles them into view. The goal is to present related but not necessary information such as asides or citations <em>as close as possible</em> to the text that references them. At the same time, this secondary information should stay out of the way of the eye, not interfering with the progression of ideas in the main text.</p>
       <p>Sidenotes consist of two elements: a superscript reference number that goes inline with the text, and a sidenote with content. To add the former, just put a label and dummy checkbox into the text where you want the reference to go, like so:</p>
@@ -91,7 +91,7 @@
     </section>
 
     <section>
-      <h2>Figures</h2>
+      <h2 id="figures">Figures</h2>
       <p>Tufte emphasizes tight integration of graphics with text. Data, graphs, and figures are kept with the text that discusses them. In print, this means they are not relegated to a separate page. On the web, that means readability of graphics and their accompanying text without extra clicks, tab-switching, or scrolling.</p>
       <p>Figures should try to use the <span class="code">figure</span> element, which by default are constrained to the main column. Don’t wrap figures in a paragraph tag. Any label or margin note goes in a regular margin note inside the figure. For example, most of the time one should introduce a figure directly into the main flow of discussion, like so:</p>
       <figure>
@@ -107,7 +107,7 @@
     </section>
 
     <section>
-      <h2>Code</h2>
+      <h2 id="code">Code</h2>
       <p>Technical jargon, programming language terms, and code samples are denoted with the <span class="code">code</span> class, as I’ve been using in this document to denote HTML. Code needs to be monospace for formatting purposes and to aid in code analysis, but it must maintain its readability. To those ends, Tufte CSS follows GitHub’s font selection, which shifts gracefully along the monospace spectrum from the elegant but rare Consolas all the way to good old reliable Courier.</p>
       <p>Extended code examples should use a <span class="code">pre</span> tag with class <span class="code">code</span>. This adds control over indentation and overflow as well:</p>
       <pre class="code">
@@ -132,7 +132,7 @@
     </section>
 
     <section>
-      <h2>ImageQuilts</h2>
+      <h2 id="imagequilts">ImageQuilts</h2>
       <p>Tufte CSS provides support for Edward Tufte and Adam Schwartz’s <a href="http://imagequilts.com/">ImageQuilts</a>. Some have ragged edges, others straight. Include these images just as you would any other <span class="code">figure</span>.</p>
       <p>This is an ImageQuilt surveying Chinese calligraphy, placed in a full-width figure to accomodate its girth:</p>
       <figure class="fullwidth"><img src="img/imagequilt-chinese-calligraphy.png" alt="Image of Chinese Calligraphy"/></figure>
@@ -141,7 +141,7 @@
     </section>
 
     <section>
-      <h2>Epilogue</h2>
+      <h2 id="epilogue">Epilogue</h2>
       <p>Many thanks go to Edward Tufte for leading the way with his work. It is only through his kind and careful editing that this project accomplishes what it does. All errors of implementation are of course mine.</p>
     </section>
     


### PR DESCRIPTION
I'm not sure if we want to do this, but I've added id's to `h1`s through `h3`s so that they can be referenced in page urls (https://edwardtufte.github.io/tufte-css/#fundamentals). 

Also for discussion: should headers when referenced like this show some indication of being referenced (done via the `:target` pseudo-class) ?
