### PR TITLE
Add highlight for targeted headers

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -68,7 +68,8 @@ h3 { font-style: italic;
      margin-bottom: 0;
      line-height: 1; }
      
-h1:target, h2:target, h3:target { box-shadow: 0 1rem #eeeeec; }
+h1:target, h2:target, h3:target { box-shadow: 0 1rem #eeeeec;
+                                  display: inline-block; }
 
 p.subtitle { font-style: italic;
              margin-top: 1rem;

--- a/tufte.css
+++ b/tufte.css
@@ -67,6 +67,8 @@ h3 { font-style: italic;
      margin-top: 2rem;
      margin-bottom: 0;
      line-height: 1; }
+     
+h1:target, h2:target, h3:target { box-shadow: 0 1rem #eeeeec; }
 
 p.subtitle { font-style: italic;
              margin-top: 1rem;


### PR DESCRIPTION
This is so that when a header is specified in the url, the header itself shows that it was referenced.

Looks like this at the moment:
![screen shot 2016-01-31 at 1 13 58 pm](https://cloud.githubusercontent.com/assets/5727389/12703906/99135c9e-c81c-11e5-98e4-638b66c0ade7.png)

I don't know if this is the best way to indicate that a header is targeted - do you think it should be more obvious (maybe a saturated colour), and/or a colour or shade that just fades out?
Please let me know what you think!
