### PR TITLE
Reduce font size and provide new fullwidth class for code

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -222,8 +222,8 @@ div.table-wrapper { overflow-x: auto;
         letter-spacing: .03em; }
 
 .code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
-        font-size: 1.125rem;
-        line-height: 1.6; }
+        font-size: 1.0rem;
+        line-height: 1.42; }
 
 h1 .code, h2 .code, h3 .code { font-size: 0.80em; }
 
@@ -232,6 +232,8 @@ h1 .code, h2 .code, h3 .code { font-size: 0.80em; }
 pre.code { width: 52.5%;
            padding-left: 2.5%;
            overflow-x: auto; }
+
+pre.code.fullwidth { width: 90%; }
 
 .fullwidth { max-width: 90%;
              clear:both; }


### PR DESCRIPTION
Wrapping + indent with pure CSS looks like a no go [1].  It is possible to do
with Javascript, but it gets complex to do right; for example, rewrapping on
a browser resize event.

So, take solution from @Norgat in edwardtufte/tufte-css#80 plus bump the font
down to 1rem.  This gives you:

```
100 characters @ body width of 1040px
 80 @ 828px
 73 @ 750px (css break)
```

Seems like the best we can do.

Note that stackoverflow takes the same approach with code snippets; there is no
wrapping and you have to scroll horizontally.  So this UX is what most coders
are used to on the web.

It's kind of funny that neither Microsoft's [2], Google's [3] or iOS [4] style
guides mention showing code as text!

[1] http://stackoverflow.com/a/3750513
[2] https://msdn.microsoft.com/en-us/windows/uwp/controls-and-patterns/fonts
[3] https://material.google.com/style/typography.html#
[4] https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/ColorImagesText.html#//apple_ref/doc/uid/TP40006556-CH58-SW1
