### PR TITLE
Quote "monospace" in `code` definition

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -200,7 +200,7 @@ div.table-wrapper { overflow-x: auto;
 .sans { font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
         letter-spacing: .03em; }
 
-code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+code { font-family: Consolas, "Liberation Mono", Menlo, Courier, "monospace";
        font-size: 1.0rem;
        line-height: 1.42; }
 


### PR DESCRIPTION
Unfortunately, Firefox does not correctly use a monospace font when
`font-family: monospace` is used unless it is quoted.
