### PR TITLE
Remove charset from css file

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -1,8 +1,6 @@
 /* Import ET Book styles
    adapted from https://github.com/edwardtufte/et-book/blob/gh-pages/et-book.css */
 
-@charset "UTF-8";
-
 @font-face { font-family: "et-book";
              src: url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.eot");
              src: url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.eot?#iefix") format("embedded-opentype"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.woff") format("woff"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.ttf") format("truetype"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.svg#etbookromanosf") format("svg");


### PR DESCRIPTION
A charset is already defined in index.html#L4.
> If you do that, there is no need to declare the encoding of your style sheet.
> —https://www.w3.org/International/questions/qa-css-charset#quickanswer