### PR TITLE
TLC for Lists

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -120,7 +120,8 @@ section > p, section > footer, section > table { width: 55%; }
 /* 50 + 5 == 55, to be the same width as paragraph */
 section > ol, section > ul { width: 50%;
                              -webkit-padding-start: 5%; }
-li { padding: 0.5rem 0; }
+
+li:not(:first-child) { margin-top: 0.25rem; }
 
 figure { padding: 0;
          border: 0;

--- a/tufte.css
+++ b/tufte.css
@@ -115,10 +115,11 @@ blockquote footer { width: 55%;
                     font-size: 1.1rem;
                     text-align: right; }
 
-section>ol, section>ul { width: 45%;
-                         -webkit-padding-start: 5%;
-                         -webkit-padding-end: 5%; }
+section > p, section > footer, section > table { width: 55%; }
 
+/* 50 + 5 == 55, to be the same width as paragraph */
+section > ol, section > ul { width: 50%;
+                             -webkit-padding-start: 5%; }
 li { padding: 0.5rem 0; }
 
 figure { padding: 0;
@@ -197,8 +198,6 @@ blockquote .sidenote, blockquote .marginnote { margin-right: -82%;
                                                min-width: 59%;
                                                text-align: left; }
 
-p, footer, table { width: 55%; }
-
 div.fullwidth, table.fullwidth { width: 100%; }
 
 div.table-wrapper { overflow-x: auto;
@@ -250,7 +249,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
 @media (max-width: 760px) { body { width: 84%;
                                    padding-left: 8%;
                                    padding-right: 8%; }
-                            p, footer { width: 100%; }
+                            section > p, section > footer, section > table { width: 100%; }
                             pre.code { width: 97%; }
                             section > ol { width: 90%; }
                             section > ul { width: 90%; }

--- a/tufte.css
+++ b/tufte.css
@@ -85,10 +85,10 @@ article { position: relative;
 section { padding-top: 1rem;
           padding-bottom: 1rem; }
 
-p, ol, ul { font-size: 1.4rem; }
+p, ol, ul { font-size: 1.4rem;
+            line-height: 2rem; }
 
-p { line-height: 2rem;
-    margin-top: 1.4rem;
+p { margin-top: 1.4rem;
     margin-bottom: 1.4rem;
     padding-right: 0;
     vertical-align: baseline; }


### PR DESCRIPTION
Fixes #117.

### Commit Summary

There are three changes to this PR. They're broken down by commit:

  - **Consistent line height in lists & paragraphs** (96311a0)

  - **Only restrict width for top-level paragraphs** (52e8fd0)

    Top-level paragraphs should take up a percentage of the surrounding
    `<section>`. All other paragraphs, (for example, those nested inside a
    list, in a sidenote, etc.) should have the default: 100%.

  - **Use margin instead of padding for lists** (8147337)

    Using margin instead of padding is preferred for nested lists.

    We also drop the padding from 0.5rem to 0.25rem. For use cases where
    you want a lot of spacing between the list items, you should be
    wrapping the contents of the list item in a paragraph tag.

### Testing

You can apply this patch to `index.html` to get some tests cases for testing
out lists (to make sure that there are no regressions).

<details>
<summary>Click to reveal patch</summary>

```diff
diff --git a/index.html b/index.html
index 1a1027b..c99df34 100644
--- a/index.html
+++ b/index.html
@@ -157,6 +157,99 @@
         <h2 id="epilogue">Epilogue</h2>
         <p>Many thanks go to Edward Tufte for leading the way with his work. It is only through his kind and careful editing that this project accomplishes what it does. All errors of implementation are of course mine.</p>
       </section>
+
+      <section>
+        <h2 id="lists-testing">Lists!</h2>
+        <p>Simple lists (single line, no line wraps):</p>
+        <ul>
+          <li>A list item</li>
+          <li>Another item</li>
+          <li>One last item</li>
+        </ul>
+        <p>Longer lists (not wrapped in paragraph tags):</p>
+        <ul>
+          <li>
+            Tufte CSS provides tools to style web articles using the ideas
+            demonstrated by Edward Tufte’s books and handouts. Tufte’s style is
+            known for its simplicity, extensive use of sidenotes, tight
+            integration of graphics with text, and carefully chosen
+            typography.
+            <label for="mn-test1" class="margin-toggle">&#8853;</label>
+            <input type="checkbox" id="mn-test1" class="margin-toggle"/>
+            <span class="marginnote">
+              Margin notes on lists line up at the same width as all other notes.
+            </span>
+          </li>
+          <li>
+            Finally, a reminder about the goal of this project. The web is not
+            print. Webpages are not books. Therefore, the goal of Tufte CSS is
+            not to say “websites should look like this interpretation of
+            Tufte’s books” but rather “here are some techniques Tufte developed
+            that we’ve found useful in print; maybe you can find a way to make
+            them useful on the web”. Tufte CSS is merely a sketch of one way to
+            implement this particular set of ideas. It should be a starting
+            point, not a design goal, because any project should present their
+            information as best suits their particular circumstances.
+          </li>
+          <li>
+            Technical jargon, programming language terms, and code samples are
+            denoted with the <code>code</code> class, as I’ve been using in this
+            document to denote HTML. Code needs to be monospace for formatting
+            purposes and to aid in code analysis, but it must maintain its
+            readability. To those ends, Tufte CSS follows GitHub’s font
+            selection, which shifts gracefully along the monospace spectrum from
+            the elegant but rare Consolas all the way to good old reliable
+            Courier.
+          </li>
+        </ul>
+        <p>Longer lists (1-2 paragraphs per list item):</p>
+        <ul>
+          <li>
+            <p>
+            Tufte CSS provides tools to style web articles using the ideas
+            demonstrated by Edward Tufte’s books and handouts. Tufte’s style is
+            known for its simplicity, extensive use of sidenotes, tight
+            integration of graphics with text, and carefully chosen
+            typography.
+            </p>
+          </li>
+          <li>
+            <p>
+            Finally, a reminder about the goal of this project. The web is not
+            print. Webpages are not books. Therefore, the goal of Tufte CSS is
+            not to say “websites should look like this interpretation of
+            Tufte’s books” but rather “here are some techniques Tufte developed
+            that we’ve found useful in print; maybe you can find a way to make
+            them useful on the web”.
+            <label for="mn-test2" class="margin-toggle">&#8853;</label>
+            <input type="checkbox" id="mn-test2" class="margin-toggle"/>
+            <span class="marginnote">
+              Correct margin notes when list item has paragraph tag.
+            </span>
+            </p>
+            <p>
+            Tufte CSS is merely a sketch of one way to
+            implement this particular set of ideas. It should be a starting
+            point, not a design goal, because any project should present their
+            information as best suits their particular circumstances.
+            </p>
+          </li>
+          <li>
+            <p>
+            Technical jargon, programming language terms, and code samples are
+            denoted with the <code>code</code> class, as I’ve been using in this
+            document to denote HTML. Code needs to be monospace for formatting
+            purposes and to aid in code analysis, but it must maintain its
+            readability.
+            </p>
+            <p>
+            To those ends, Tufte CSS follows GitHub’s font
+            selection, which shifts gracefully along the monospace spectrum from
+            the elegant but rare Consolas all the way to good old reliable
+            Courier.
+            </p>
+          </li>
+      </section>
     </article>
   </body>
 </html>
```

</details>