### PR TITLE
Proposal: Update the monospaced font family

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -207,7 +207,7 @@ div.table-wrapper { overflow-x: auto;
 .sans { font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
         letter-spacing: .03em; }
 
-code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+code { font-family: Consolas, "DejaVu Sans Mono", Menlo, monospace;
        font-size: 1.0rem;
        line-height: 1.42; }
 


### PR DESCRIPTION
As Menlo is a variant of DejaVu Sans Mono, I suggest using the latter instead of RedHat's Liberation fonts for more unified look across operating systems (every desktop Linux distro I know of includes the DejaVu Sans Mono font by default.)

Also, There's no need to explicitly mention Courier, as it's what monospace defaults to — in the worst case scenario.