### PR TITLE
Remove redundant sidenote counter

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -180,8 +180,7 @@ img { max-width: 100%; }
 
 .sidenote-number { counter-increment: sidenote-counter; }
 
-.sidenote-number:after, .sidenote:before { content: counter(sidenote-counter) " ";
-                                           font-family: et-book-roman-old-style;
+.sidenote-number:after, .sidenote:before { font-family: et-book-roman-old-style;
                                            position: relative;
                                            vertical-align: baseline; }
 


### PR DESCRIPTION
As mentioned in #114, the counter for `sidenote-counter` is defined twice.