### PR TITLE
[Design] Update default table styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,42 @@
       </section>
 
       <section>
+        <h2 id="tables">Tables</h2>
+        <p>Tufte CSS also provides support for basic table layouts:</p>
+        <table>
+          <thead>
+            <tr>
+              <td>Cities</td>
+              <td>Numbers</td>
+              <td>Animals</td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Toronto</td>
+              <td>13</td>
+              <td>Tiger</td>
+            </tr>
+            <tr>
+              <td>New York</td>
+              <td>27</td>
+              <td>Elephant</td>
+            </tr>
+            <tr>
+              <td>Berlin</td>
+              <td>756</td>
+              <td>Monkey</td>
+            </tr>
+            <tr>
+              <td>Moscow</td>
+              <td>233</td>
+              <td>Rhino</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
         <h2 id="epilogue">Epilogue</h2>
         <p>Many thanks go to Edward Tufte for leading the way with his work. It is only through his kind and careful editing that this project accomplishes what it does. All errors of implementation are of course mine.</p>
       </section>

--- a/tufte.css
+++ b/tufte.css
@@ -85,7 +85,7 @@ article { position: relative;
 section { padding-top: 1rem;
           padding-bottom: 1rem; }
 
-p, ol, ul { font-size: 1.4rem; }
+p, ol, ul, table { font-size: 1.4rem; }
 
 p { line-height: 2rem;
     margin-top: 1.4rem;
@@ -203,6 +203,25 @@ div.fullwidth, table.fullwidth { width: 100%; }
 
 div.table-wrapper { overflow-x: auto;
                     font-family: "Trebuchet MS", "Gill Sans", "Gill Sans MT", sans-serif; }
+
+table { border-collapse: collapse;
+        border-left: 1px solid #333;
+        border-right: 1px solid #333;
+        border-top: 1px solid #333;
+        margin: 2rem 0; }
+
+table thead { background: rgba(0,0,0,0.08);
+              font-size: 1rem;
+              font-weight: 600;
+              text-transform: uppercase; }
+
+table tr:nth-child(even) { background: rgba(0,0,0,0.02); }
+
+table td { border-bottom: 1px solid #333;
+           border-left: 1px solid #333;
+           padding: 1rem; }
+
+table td:nth-child(1) { border-left: 0; }
 
 .sans { font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
         letter-spacing: .03em; }


### PR DESCRIPTION
### Details

Add additional styling for default HTML table elements. 
(If the default styling is preferred, then please just disregard this PR 😄 )

See updates below:

#### Before - Default
<img width="562" alt="screen shot 2017-11-07 at 12 25 04 pm" src="https://user-images.githubusercontent.com/1873938/32508367-14bca92a-c3b8-11e7-91ed-95033200014a.png">

#### Before w/ `.table-wrapper`
<img width="554" alt="screen shot 2017-11-07 at 12 24 51 pm" src="https://user-images.githubusercontent.com/1873938/32508344-01457106-c3b8-11e7-9281-ced48b2dfb91.png">

---

#### After - Default
<img width="671" alt="screen shot 2017-11-07 at 12 23 57 pm" src="https://user-images.githubusercontent.com/1873938/32508382-214d050e-c3b8-11e7-9f3f-55c2f6c59f7d.png">

#### After w/ `.table-wrapper`
<img width="662" alt="screen shot 2017-11-07 at 12 24 23 pm" src="https://user-images.githubusercontent.com/1873938/32508390-2abe4aa8-c3b8-11e7-8a89-c2630de4613f.png">
