### PR TITLE
Make 'h2'/'h3' margin consistent with 'p' margin

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -49,7 +49,7 @@ h1 { font-weight: 400;
 h2 { font-style: italic;
      font-weight: 400;
      margin-top: 2.1rem;
-     margin-bottom: 0;
+     margin-bottom: 1.4rem;
      font-size: 2.2rem;
      line-height: 1; }
 
@@ -57,7 +57,7 @@ h3 { font-style: italic;
      font-weight: 400;
      font-size: 1.7rem;
      margin-top: 2rem;
-     margin-bottom: 0;
+     margin-bottom: 1.4rem;
      line-height: 1; }
 
 hr { display: block;


### PR DESCRIPTION
### Context

The margin-top and margin-bottom on a `<p>` tag is 1.4rem.  When two
`<p>` tags are adjacent to each other, the margin bottom of the first
and the margin top of the second collapse together—they're only
separated by 1.4rem total.

On the other hand, the margin-bottom on `<h2>` and `<h3>` is 0.
Normally this is fine, because of the time a `<p>` follows the heading,
so the margin-top on the paragraph picks up the correct vertical
spacing.

### Problem & Proposed Solution

The problem is when a heading isn't followed by a paragraph (let's say:
a generic `<div>`). If that div doesn't set margin-top like paragraphs do,
then both the heading and the div will be 0px apart. (In particular, if
there are descenders in the heading, they'll overlap!)

There are then two solutions:

1. Set a margin-bottom on the heading
2. Set a margin-top on the div

Setting a margin-top on the div essentially adds a *special case* for
the div. On the other hand, setting a margin-bottom solves the *general
case* of "vertical spacing after a heading."

### Implications

For the common case of headings + paragraphs, there will be no change, because
paragraphs already set a corresponding margin-top.

For cases where people were depending on this `margin-bottom: 0`, they will see
extra space after headings. I believe this isn't something people are actively
depending on.

That being said, I totally understand if you don't want to merge in this change
on the off chance that it would break someone else's page.
As always, thanks for this project! 🙂