### PR TITLE
Make horizontal rules responsive

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -249,7 +249,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
 @media (max-width: 760px) { body { width: 84%;
                                    padding-left: 8%;
                                    padding-right: 8%; }
-                            section > p, section > footer, section > table { width: 100%; }
+                            hr, section > p, section > footer, section > table { width: 100%; }
                             pre.code { width: 97%; }
                             section > ol { width: 90%; }
                             section > ul { width: 90%; }


### PR DESCRIPTION
Currently `<hr>`elements stay 55% wide regardless of screen size. By including them in the `@media` rule, they become responsive.