### PR TITLE
Build system proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "tufte-css",
+  "version": "1.3.0",
+  "description": "Edward Tufte uses a distinctive style in his handouts: simple, with well-set typography, extensive sidenotes, and tight integration of graphics and charts.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/edwardtufte/tufte-css.git"
+  },
+  "keywords": [
+    "tufte",
+    "css",
+    "HTML",
+    "typography",
+    "sidenotes"
+  ],
+  "author": "Dave Liepmann",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/edwardtufte/tufte-css/issues"
+  },
+  "homepage": "https://github.com/edwardtufte/tufte-css#readme",
+  "devDependencies": {
+    "csso": "^3.5.1",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tufte-css",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "Edward Tufte uses a distinctive style in his handouts: simple, with well-set typography, extensive sidenotes, and tight integration of graphics and charts.",
   "repository": {
     "type": "git",

--- a/tufteTasks.js
+++ b/tufteTasks.js
@@ -1,0 +1,122 @@
+var csso = require('csso');
+var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
+
+const fs = require('fs');
+const join = require('path').join;
+
+var exports = module.exports = {};
+
+exports.tufteUpdate = function() {
+  var execPromise = new Promise(function(resolve, reject) {
+    exec("git submodule update --remote", function(err, stdout, stderr)
+      {
+        console.log("Output: \n" + stdout);
+        if(err)
+        {
+          console.log("Error: \n" + stderr);
+        }
+        resolve();
+      });
+  });
+  return execPromise;
+}
+
+exports.tufteUpdateSync = function() {
+  try {
+    var output = execSync("git pull");
+    console.log("Output: "+output);
+  } catch(error) {
+    console.log("Error: " + error.stderr);
+  }
+}
+
+const deletableTufteEntries = [
+  'index.html',
+  'README.md',
+  'LICENSE',
+  'img'
+];
+
+exports.tuftePrune = function() {
+  let paths = deletableTufteEntries.Map(entry => join(__dirname, entry));
+  return Promise.all(paths.Map(path => 
+    fs.promises.stat(path).then(
+      (status) => {
+        if (status.isDirectory()) //It's tufte-css/img, which containssome images
+        {
+          return fs.promises.readdir(path).then(
+            (items) => {
+              Promise.all(items.Map(item => {
+                return fs.promises.unlink(path+'/'+item);
+              })).then(() =>
+                {
+                  return fs.promises.rmdir(path);
+                }
+              );
+            }
+          );
+        }
+        else
+        {
+          return fs.promises.unlink(path);
+        }
+      })
+  ));
+}
+
+exports.tuftePruneSync = function() {
+  deletableTufteEntries.forEach(function(entry)
+  {
+    console.log(typeof(__dirname));
+    console.log(typeof(entry))
+    console.log(entry)
+    var path = join(__dirname, entry);
+    try
+    {
+      stat = fs.statSync(path);
+      if (stat.isDirectory())
+      {
+        var img_files = fs.readdirSync(path);
+        img_files.forEach(function(img)
+        {
+          fs.unlinkSync(path+'/'+img);
+        });
+        fs.rmdirSync(path);
+      }
+      else
+      {
+        fs.unlinkSync(path);
+      }
+    }
+    catch(error)
+    {
+    }
+  });
+}
+
+cssFiles = [
+  'latex.css',
+  'tufte.css'
+];
+
+exports.tufteMinify = function()
+{
+  return Promise.all(cssFiles.Map(
+    (cssFile) => 
+      fs.promises.readFile(cssFile).then(
+        (stream) => {
+          var outFile = cssFile.replace('.css', '.min.css');
+          return fs.promises.writeFile(outFile, csso.minify(stream));
+        })
+    ));
+}
+
+exports.tufteMinifySync = function()
+{
+  cssFiles.forEach(function(file, index, array){
+    var stream = fs.readFileSync(file);
+    var outFile = file.replace('.css','.min.css')
+    fs.writeFileSync(outFile, csso.minify(stream).css);
+  });
+}

--- a/tufteTasks.js
+++ b/tufteTasks.js
@@ -39,15 +39,15 @@ const deletableTufteEntries = [
 ];
 
 exports.tuftePrune = function() {
-  let paths = deletableTufteEntries.Map(entry => join(__dirname, entry));
-  return Promise.all(paths.Map(path => 
+  let paths = deletableTufteEntries.map(entry => join(__dirname, entry));
+  return Promise.all(paths.map(path => 
     fs.promises.stat(path).then(
       (status) => {
         if (status.isDirectory()) //It's tufte-css/img, which containssome images
         {
           return fs.promises.readdir(path).then(
             (items) => {
-              Promise.all(items.Map(item => {
+              Promise.all(items.map(item => {
                 return fs.promises.unlink(path+'/'+item);
               })).then(() =>
                 {
@@ -61,16 +61,15 @@ exports.tuftePrune = function() {
         {
           return fs.promises.unlink(path);
         }
-      })
+      }).catch( // If stat errors, the file is missing and we continue
+        () => {}
+      )
   ));
 }
 
 exports.tuftePruneSync = function() {
   deletableTufteEntries.forEach(function(entry)
   {
-    console.log(typeof(__dirname));
-    console.log(typeof(entry))
-    console.log(entry)
     var path = join(__dirname, entry);
     try
     {
@@ -102,12 +101,12 @@ cssFiles = [
 
 exports.tufteMinify = function()
 {
-  return Promise.all(cssFiles.Map(
+  return Promise.all(cssFiles.map(
     (cssFile) => 
       fs.promises.readFile(cssFile).then(
         (stream) => {
           var outFile = cssFile.replace('.css', '.min.css');
-          return fs.promises.writeFile(outFile, csso.minify(stream));
+          return fs.promises.writeFile(outFile, csso.minify(stream).css);
         })
     ));
 }

--- a/tufteTasks.js
+++ b/tufteTasks.js
@@ -101,7 +101,8 @@ cssFiles = [
 
 exports.tufteMinify = function()
 {
-  return Promise.all(cssFiles.map(
+  let paths = cssFiles.map(file=> join(__dirname,file));
+  return Promise.all(paths.map(
     (cssFile) => 
       fs.promises.readFile(cssFile).then(
         (stream) => {
@@ -114,8 +115,9 @@ exports.tufteMinify = function()
 exports.tufteMinifySync = function()
 {
   cssFiles.forEach(function(file, index, array){
-    var stream = fs.readFileSync(file);
-    var outFile = file.replace('.css','.min.css')
+    var path = join(__dirname, file);
+    var stream = fs.readFileSync(path);
+    var outFile = path.replace('.css','.min.css')
     fs.writeFileSync(outFile, csso.minify(stream).css);
   });
 }


### PR DESCRIPTION
Previous issues have discussed adding a minified css or a build system to tufte-css. This Pull Request is a proposal for that, based on javascript build systems like [gulp](https://gulpjs.com/) or [grunt](https://gruntjs.com/). 

We choose javascript as build pipelines using npm and node seem to have become a defacto standard for web projects, even in projects built in other languages and using other frameworks (see e.g [Mozilla's blogpost on moving to gulp as part of a Django project](https://blog.mozilla.org/webdev/2016/05/27/django-pipeline-and-gulp/).)

Here, we add a package.json (inspired by #109 ), and a small javascript module called `tufteTasks.js`. This file defines three helper functions to:
1. Pull updates from github
2. Prune all non-css files from the directory
3. Minify the CSS files

These are availabe as both synchronous functions, or asynchronous functions returning Promises, for use with either Grunt or Gulp respectively.

For example, in my project, which has `tufte-css` as a submodule in the root, my gulpfile would look something like
```javascript
const tufteTasks = require('tufte-css/tufteTasks.js');
const gulp = require('gulp');

gulp.task('minify-tufte', function() {
  tufteTasks.tufteUpdate().then(() =>
  {
    tufteTasks.tufteMinify().then(
       ()=> {
        gulp.src('./tufte-css/*.min.css')
        .pipe(gulp.dest('./build/'));
       }
    );
  });
});
``` 
which checks for updates, minifies the css, and moves those files to the build directory when the promise resolves.