### PR TITLE
Align list and paragraph right edges with body text

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -106,10 +106,15 @@ div.epigraph > blockquote > footer { font-style: normal; }
 div.epigraph > blockquote > footer > cite { font-style: italic; }
 /* end chapter epigraphs styles */
 
-blockquote { font-size: 1.4rem; }
+blockquote { font-size: 1.4rem;
+             margin-left: 5%;
+             margin-right: 5%; }
 
-blockquote p { width: 55%;
+blockquote p { width: 55.555%;
                margin-right: 40px; }
+
+blockquote > ul, blockquote > ol { width: 50.555%;
+                                   -webkit-padding-start: 5%; }
 
 blockquote footer { width: 55%;
                     font-size: 1.1rem;
@@ -260,6 +265,7 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
                             blockquote { margin-left: 1.5em;
                                          margin-right: 0em; }
                             blockquote p, blockquote footer { width: 100%; }
+                            blockquote ol, blockquote ul { width: auto; }
                             label.margin-toggle:not(.sidenote-number) { display: inline; }
                             .sidenote, .marginnote { display: none; }
                             .margin-toggle:checked + .sidenote,


### PR DESCRIPTION
This change fixes the width of lists and paragraphs inside blockquotes so that their right edges are aligned with the right edge of the body text.

Here is a test document:

```html
<!DOCTYPE html>
<html>
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
  <title>Test lists inside blockquotes</title>
  <link rel="stylesheet" href="tufte.css">
</head>
<body>
<article>
<section id="test-lists-inside-blockquotes" class="level1">
<h1>Test lists inside blockquotes</h1>
<p>The Sixth Party Congress of the Russian Social-Democratic Labour Party (Bolsheviks) held at Petrograd between 26 July and 3 August 1917 defined democratic centralism as follows:</p>
<blockquote>
<ol type="1">
<li>That all directing bodies of the Party, from top to bottom, shall be elected.</li>
<li>That Party bodies shall give periodical accounts of their activities to their respective Party organizations.</li>
<li>That there shall be strict Party discipline and the subordination of the minority to the majority.</li>
<li>That all decisions of higher bodies shall be absolutely binding on lower bodies and on all Party members.</li>
</ol>
</blockquote>
</section>
</article>
</body>
</html>
```

