### PR TITLE
use currentColor for link underline

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -149,8 +149,8 @@ figure.fullwidth figcaption { margin-right: 24%; }
 a:link, a:visited { color: inherit; }
 
 a:link { text-decoration: none;
-         background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#333, #333);
-         background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(#333, #333);
+         background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(currentColor, currentColor);
+         background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(currentColor, currentColor);
          -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
          -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
          background-size: 0.05em 1px, 0.05em 1px, 1px 1px;


### PR DESCRIPTION
The css `currentColor` has ~99% coverage (https://caniuse.com/#search=currentColor) and would match the link underline with the current color of the link.