### PR TITLE
tufte-underline extensions

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -241,15 +241,10 @@ a:link, .tufte-underline, .hover-tufte-underline:hover {
     }
 }
 
-a:link::selection, 
+a:link::selection,
 a:link::-moz-selection {
     text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
     background: #b4d5fe;
-}
-
-a.no-tufte-underline:link::selection, a.no-tufte-underline:link::-moz-selection {
-    text-shadow: unset;
-    background: unset;
 }
 
 /* Sidenotes, margin notes, figures, captions */

--- a/tufte.css
+++ b/tufte.css
@@ -218,7 +218,12 @@ a:visited {
     color: inherit; 
 }
 
-a:link {
+.no-tufte-underline:link {
+    background: unset;
+    text-shadow: unset;
+}
+
+a:link, .tufte-underline, .hover-tufte-underline:hover {
     text-decoration: none;
     background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(currentColor, currentColor);
     background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(currentColor, currentColor);
@@ -231,15 +236,20 @@ a:link {
 }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-    a:link {
+    a:link, .tufte-underline, .hover-tufte-underline:hover {
         background-position-y: 87%, 87%, 87%;
     }
 }
 
-a:link::selection,
+a:link::selection, 
 a:link::-moz-selection {
     text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
     background: #b4d5fe;
+}
+
+a.no-tufte-underline:link::selection, a.no-tufte-underline:link::-moz-selection {
+    text-shadow: unset;
+    background: unset;
 }
 
 /* Sidenotes, margin notes, figures, captions */


### PR DESCRIPTION
Provide escape hatch + opt-in classes for tufte-underline behaviour.

- `.no-tufte-underline` removes the tufte underline style from a link
- `.tufte-underline` adds the underline style to any element
- `.hover-tufte-underline` adds the underline style to the `:hover` state of any element

One must use both `.no-tufte-underline` and `.hover-tufte-underline` classes on a link to override the existing behaviour and only underline on hover.

I didn't add any new `::selection` rules. My understanding is that these rules attempt to remove the white outline from selected link text, but I couldn't reproduce/control this behaviour reliably, and it [looks like](https://www.w3schools.com/cssref/sel_selection.asp) the text-shadow property isn't properly supported for `::selection` rules. I could totally be missing something here, and am open to alternate approaches.