### PR TITLE
Correctly format code blocks

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -312,7 +312,7 @@ div.table-wrapper {
     letter-spacing: .03em; 
 }
 
-code {
+code, pre.code {
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 1.0rem;
     line-height: 1.42;


### PR DESCRIPTION
With the change to using the semantically correct `<code>` tag, `pre.code` is no longer getting the correct font face set. By specifically addressing `pre.code` I got everything displaying as I wanted.