### PR TITLE
Align baseline of sidenote/marginnote with main text

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -262,7 +262,7 @@ img {
     clear: right;
     margin-right: -60%;
     width: 50%;
-    margin-top: 0;
+    margin-top: 0.3rem;
     margin-bottom: 0;
     font-size: 1.1rem;
     line-height: 1.3;


### PR DESCRIPTION
This adds 0.3rem of padding to the top of margin notes and sidenotes,
causing the baseline of the first line of the note to be aligned with
the baseline of the main body text.

As discussed in #134, this is the approach taken in Tufte's books.

Closes #134.

before:
![tufte_sidenote_before](https://user-images.githubusercontent.com/5001092/87033304-f90e6b80-c1b3-11ea-9711-80e0036adaed.png)

after:
![tufte_sidenote_after](https://user-images.githubusercontent.com/5001092/87033303-f90e6b80-c1b3-11ea-8c38-aa5292d1f283.png)

no impact on mobile, since the definition in the media query resets the padding already.

