### PR TITLE
Fix label number display style and margin

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -384,7 +384,7 @@ input.margin-toggle {
 
 label.sidenote-number {
     display: inline-block;
-    margin-bottom: -5%;
+    max-height: 2rem;
 }
 
 label.margin-toggle:not(.sidenote-number) {

--- a/tufte.css
+++ b/tufte.css
@@ -383,7 +383,8 @@ input.margin-toggle {
 }
 
 label.sidenote-number {
-    display: inline;
+    display: inline-block;
+    margin-bottom: -5%;
 }
 
 label.margin-toggle:not(.sidenote-number) {


### PR DESCRIPTION
I am not aware of CSS practices and have only added a rudimentary fix using Stack Overflow.

Source: [Margin-top not working with \<label\>](https://stackoverflow.com/questions/15929141/margin-top-not-working-with-label/15929278)

Feel free to request changes. This should close #167.