### PR TITLE
Fix sidenote alignment in lists.

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -288,6 +288,11 @@ img {
     position: relative;
 }
 
+li .sidenote,
+li .marginnote {
+    margin-right: -65%;
+}
+
 .sidenote-number {
     counter-increment: sidenote-counter;
 }


### PR DESCRIPTION
The 5% difference is due to the difference in the width of the p
elements and the ul/ol elements: 55% and 50%, respectively.

Fixes #170.