### PR TITLE
Add note about section tags for sidenotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
        class="margin-toggle"/&gt;</code></pre>
         <p>You must manually assign a reference <code>id</code> to each side or margin note, replacing “sn-demo” in the <code>for</code> and the <code>id</code> attribute values with an appropriate descriptor. It is useful to use prefixes like <code>sn-</code> for sidenotes and <code>mn-</code> for margin notes.</p>
         <p>Immediately adjacent to that sidenote reference in the main text goes the sidenote content itself, in a <code>span</code> with class <code>sidenote</code>. This tag is also inserted directly in the middle of the body text, but is either pushed into the margin or hidden by default. Make sure to position your sidenotes correctly by keeping the sidenote-number label close to the sidenote itself.</p>
+        <p>For optimal readibility of sidenotes, enclose the main text in the <code>section</code> tag.</p>
         <p>If you want a sidenote without footnote-style numberings, then you want a margin note.
           <label for="mn-demo" class="margin-toggle">&#8853;</label>
           <input type="checkbox" id="mn-demo" class="margin-toggle"/>


### PR DESCRIPTION
Sidenotes work better when the main text is enclosed in the section tag. Tested on Microsoft Edge and Mozilla Firefox. The first two screenshots show that without the section tag, the sidenote is too far apart from the main text. The last screenshot shows the result when section tag is used. 
![scr1](https://github.com/user-attachments/assets/a5e52573-01e1-4b1a-a18f-c55ed5872227)
![scr2](https://github.com/user-attachments/assets/c498c36e-fcf0-434d-9ffb-949afd3906b8)
![scr3](https://github.com/user-attachments/assets/fb007535-de67-4407-a93e-de20fed22859)


