### PR TITLE
Use percentage for html font-size

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -41,7 +41,7 @@
 
 /* Tufte CSS styles */
 html {
-    font-size: 15px;
+    font-size: 93.75%;
 }
 
 body {


### PR DESCRIPTION
Sets `font-size` for `html` to `93.75%` instead of `15px`, as using `px` for root `font-size` creates an accessibility issue by preventing users' default font sizes from being applied.

The tradeoff for this approach is possible compatibility issues for third-party CSS, but I imagine anyone using Tufte CSS isn't looking to complicate their design anyway.

@joshwcomeau wrote a [helpful article](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/) about the use of different size units w/r/t accessibility, in which he also provides other solutions to this, though I think the percentage would work just fine here without requiring a refactor.