### PR TITLE
Fix image scaling issue

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -237,6 +237,7 @@ a:visited {
 /* Sidenotes, margin notes, figures, captions */
 img {
     max-width: 100%;
+    height: auto;
 }
 
 .sidenote,


### PR DESCRIPTION
When an image has an explicit width and height, the `max-width` specification on images rescales the width down, but leaves the explicit height.

This does not only happen when the user sets the width and height explicitly, but may also be done by JavaScript frameworks such as Astro to optimize for the cumulative layout shift metric, see [this section in the Astro documentation](https://docs.astro.build/en/guides/images/#display-optimized-images-with-the-image--component).

This PR fixes this issue by setting `height: auto` for images.