### PR TITLE
fix keyboard accessibility of sidenotes on narrow viewports / larger zooms

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -359,6 +359,10 @@ input.margin-toggle {
     width: 0;
 }
 
+label.margin-toggle:has(+ input:focus-visible) {
+    outline: auto;
+}
+
 label.sidenote-number {
     display: inline-block;
     max-height: 2rem; /* should be less than or equal to paragraph line-height */

--- a/tufte.css
+++ b/tufte.css
@@ -353,7 +353,10 @@ span.newthought {
 }
 
 input.margin-toggle {
-    display: none;
+    height: 0;
+    opacity: 0;
+    position: absolute;
+    width: 0;
 }
 
 label.sidenote-number {

--- a/tufte.css
+++ b/tufte.css
@@ -353,14 +353,7 @@ span.newthought {
 }
 
 input.margin-toggle {
-    height: 0;
-    opacity: 0;
-    position: absolute;
-    width: 0;
-}
-
-label.margin-toggle:has(+ input:focus-visible) {
-    outline: auto;
+    display: none;
 }
 
 label.sidenote-number {
@@ -429,6 +422,18 @@ label.margin-toggle:not(.sidenote-number) {
     blockquote p,
     blockquote footer {
         width: 100%;
+    }
+
+    input.margin-toggle {
+        display: inline-block;
+        height: 0;
+        opacity: 0;
+        position: absolute;
+        width: 0;
+    }
+
+    label.margin-toggle:has(+ input:focus-visible) {
+        outline: auto;
     }
 
     label.margin-toggle:not(.sidenote-number) {


### PR DESCRIPTION
fixes #195 

- visually hide the input rather than `display:none`
- allow input focus state to effect the label styles

Video of testing on the repos index.html.


https://github.com/user-attachments/assets/efb7face-37c6-459f-afba-dca004e8ed33

